### PR TITLE
fix: IP warning when not using official API & draggable thumb (fixes #544, #715)

### DIFF
--- a/src/common/components/IpLocationNotification.tsx
+++ b/src/common/components/IpLocationNotification.tsx
@@ -6,11 +6,12 @@ import { IpLocation, getIpLocationInfo } from '../geo'
 import { isUsingOpenAIOfficial } from '../utils'
 import { ISettings } from '../types'
 
-export default function IpLocationNotification(settings: ISettings) {
+export default function IpLocationNotification(props: { showSettings: boolean }) {
     const [ipLocation, setIpLocation] = useState<IpLocation | null>(null)
     useEffect(
         () => {
             ;(async () => {
+                console.log('refreshed!', props)
                 setIpLocation(
                     (await isUsingOpenAIOfficial())
                         ? await getIpLocationInfo()
@@ -18,7 +19,7 @@ export default function IpLocationNotification(settings: ISettings) {
                 )
             })()
         },
-        [settings] // refresh on provider / API endpoint change
+        [props.showSettings] // refresh on provider / API endpoint change
     )
 
     if (ipLocation === null || ipLocation.supported) return <></>

--- a/src/common/components/IpLocationNotification.tsx
+++ b/src/common/components/IpLocationNotification.tsx
@@ -4,14 +4,12 @@ import { Notification, KIND as NOTIFICATION_KIND } from 'baseui-sd/notification'
 import { StyledLink } from 'baseui-sd/link'
 import { IpLocation, getIpLocationInfo } from '../geo'
 import { isUsingOpenAIOfficial } from '../utils'
-import { ISettings } from '../types'
 
 export default function IpLocationNotification(props: { showSettings: boolean }) {
     const [ipLocation, setIpLocation] = useState<IpLocation | null>(null)
     useEffect(
         () => {
             ;(async () => {
-                console.log('refreshed!', props)
                 setIpLocation(
                     (await isUsingOpenAIOfficial())
                         ? await getIpLocationInfo()

--- a/src/common/components/IpLocationNotification.tsx
+++ b/src/common/components/IpLocationNotification.tsx
@@ -3,14 +3,23 @@ import { Trans } from 'react-i18next'
 import { Notification, KIND as NOTIFICATION_KIND } from 'baseui-sd/notification'
 import { StyledLink } from 'baseui-sd/link'
 import { IpLocation, getIpLocationInfo } from '../geo'
+import { isUsingOpenAIOfficial } from '../utils'
+import { ISettings } from '../types'
 
-export default function IpLocationNotification() {
+export default function IpLocationNotification(settings: ISettings) {
     const [ipLocation, setIpLocation] = useState<IpLocation | null>(null)
-    useEffect(() => {
-        ;(async () => {
-            setIpLocation(await getIpLocationInfo())
-        })()
-    }, [])
+    useEffect(
+        () => {
+            ;(async () => {
+                setIpLocation(
+                    (await isUsingOpenAIOfficial())
+                        ? await getIpLocationInfo()
+                        : null /* Not directly connecting to OpenAI */
+                )
+            })()
+        },
+        [settings] // refresh on provider / API endpoint change
+    )
 
     if (ipLocation === null || ipLocation.supported) return <></>
 

--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1229,7 +1229,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                     <div className={styles.popupCardContentContainer}>
                         {settings?.apiURL === defaultAPIURL && (
                             <div>
-                                <IpLocationNotification />
+                                <IpLocationNotification {...settings} />
                             </div>
                         )}
                         <div ref={editorContainerRef} className={styles.popupCardEditorContainer}>

--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1229,7 +1229,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                     <div className={styles.popupCardContentContainer}>
                         {settings?.apiURL === defaultAPIURL && (
                             <div>
-                                <IpLocationNotification {...settings} />
+                                <IpLocationNotification showSettings={showSettings} />
                             </div>
                         )}
                         <div ref={editorContainerRef} className={styles.popupCardEditorContainer}>

--- a/src/common/i18n/locales/en/translation.json
+++ b/src/common/i18n/locales/en/translation.json
@@ -39,7 +39,7 @@
   "Run at Startup": "Run at Startup",
   "API Model": "API Model",
   "Chars Limited": "The number of characters exceeds the limit",
-  "Country Not Supported": "Your IP address is from {{name}}, which is not a <0>supported region</0> of OpenAI. Continuing to use without extra network configuration may result in your account being blocked by OpenAI, regardless of your ChatGPT Plus subscription status or any remaining account balance.",
+  "Country Not Supported": "You are directly connecting to OpenAI from {{name}}, which is not a <0>supported region</0> of OpenAI. Continuing to use without extra network configuration may result in your account being blocked by OpenAI, regardless of your ChatGPT Plus subscription status or any remaining account balance.",
   "Country Not Detected": "We were unable to check if your IP address is in a <0>supported region</0> of OpenAI. Please check your Internet connection, and ensure that you are accessing the API in a supported region of OpenAI, or your account may get banned regardless of your GPT Plus subscription status or any remaining account balance.",
   "words are collected": "{{collectTotal}} words are collected",
   "Collection Review": "Collection Review",

--- a/src/common/i18n/locales/zh-Hans/translation.json
+++ b/src/common/i18n/locales/zh-Hans/translation.json
@@ -39,7 +39,7 @@
   "Run at Startup": "开机启动",
   "API Model": "API 模型",
   "Chars Limited": "字数超出限制",
-  "Country Not Supported": "您的 IP 属地为 {{name}}，不在 OpenAI <0>支持的地区</0> 范围内。如果不进行额外的网络配置继续使用，即使订阅了 ChatGPT Plus 或账号内仍有余额，您的账户也会被 OpenAI 封禁。",
+  "Country Not Supported": "您正在直接连接至 OpenAI，而您的 IP 属地为 {{name}}，不在 OpenAI <0>支持的地区</0> 范围内。如果不进行额外的网络配置继续使用，即使订阅了 ChatGPT Plus 或账号内仍有余额，您的账户也会被 OpenAI 封禁。",
   "Country Not Detected": "我们无法检查您的 IP 地址是否位于 OpenAI 的<0>支持的地区</0>，可能是由于您的网络环境无法访问 OpenAI。请检查您的网络连接，并确保您在支持的位置访问 API，否则即使订阅了 ChatGPT Plus 或账号内仍有余额，您的账户也会被 OpenAI 封禁。",
   "words are collected": "已收藏 {{collectTotal}} 个单词",
   "Collection Review": "单词复习",

--- a/src/common/i18n/locales/zh-Hant/translation.json
+++ b/src/common/i18n/locales/zh-Hant/translation.json
@@ -39,7 +39,7 @@
   "Run at Startup": "開機自啟",
   "API Model": "API 模型",
   "Chars Limited": "字數超出限制",
-  "Country Not Supported": "您的 IP 屬地為 {{name}}，不在 OpenAI <0>支援的地區</0> 範圍內。如果不進行額外的網路配置繼續使用，即使訂閱了 ChatGPT Plus 或賬戶內仍有餘額，您的賬戶也會被 OpenAI 封鎖。",
+  "Country Not Supported": "您正在直接連接至 OpenAI，而您的 IP 屬地為 {{name}}，不在 OpenAI <0>支援的地區</0> 範圍內。如果不進行額外的網路配置繼續使用，即使訂閱了 ChatGPT Plus 或賬戶內仍有餘額，您的賬戶也會被 OpenAI 封鎖。",
   "Country Not Detected": "我們無法檢查您的 IP 地址是否位於 OpenAI 的<0>支援的地區</0>，可能是由於您的網路環境無法訪問 OpenAI。請檢查您的網路連線，並確保您在支援的位置訪問 API，否則即使訂閱了 ChatGPT Plus 或賬號內仍有餘額，您的賬戶也會被 OpenAI 封鎖。",
   "words are collected": "已收藏 {{collectTotal}} 個單詞",
   "Collection Review": "單詞複習",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -139,6 +139,16 @@ export const isDarkMode = async () => {
 
 export const isFirefox = () => /firefox/i.test(navigator.userAgent)
 
+export const isUsingOpenAIOfficialAPIEndpoint = async () => {
+    const settings = await getSettings()
+    return settings.provider === defaultProvider && settings.apiURL === defaultAPIURL
+}
+
+export const isUsingOpenAIOfficial = async () => {
+    const settings = await getSettings()
+    return settings.provider === 'ChatGPT' || (await isUsingOpenAIOfficialAPIEndpoint())
+}
+
 // source: https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid#answer-8809472
 export function generateUUID() {
     let d = new Date().getTime() // Timestamp

--- a/src/tauri/thumb.tsx
+++ b/src/tauri/thumb.tsx
@@ -16,6 +16,7 @@ export function Thumb() {
                 }}
             >
                 <img
+                    draggable={false}
                     style={{
                         display: 'block',
                         width: '100%',


### PR DESCRIPTION
Do not show IP location warning if not using official API Endpoint or ChatGPT. Also, added refreshing when settings changed.