### PR TITLE
fix: banner overflow in the options view

### DIFF
--- a/src/browser-extension/options/index.css
+++ b/src/browser-extension/options/index.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/src/browser-extension/options/index.tsx
+++ b/src/browser-extension/options/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { Settings } from '../../common/components/Settings'
 import { Client as Styletron } from 'styletron-engine-atomic'
 import '../../common/i18n.js'
+import './index.css'
 
 const engine = new Styletron()
 

--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -941,6 +941,7 @@ export function InnerSettings(props: IInnerSettingsProps) {
                     color: '#333',
                     background: `url(${beams}) no-repeat center center`,
                     gap: 10,
+                    boxSizing: 'border-box',
                 }}
                 data-tauri-drag-region
             >


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

This PR fixes the banner width overflow in the Options view and Popup view.

| Before | After |
| --- | --- |
| <img width="422" alt="image" src="https://github.com/openai-translator/openai-translator/assets/16336606/957001fa-ec1d-4288-972d-5e2b6c3e31ff"> | <img width="402" alt="image" src="https://github.com/openai-translator/openai-translator/assets/16336606/38ef55cd-ff17-4e1b-84f7-53f2452a6857"> |
