### PR TITLE
fix: Fix SnipDo  Command Error

### DIFF
--- a/clip-extensions/snipdo/openai-translator.ps1
+++ b/clip-extensions/snipdo/openai-translator.ps1
@@ -4,4 +4,4 @@ param(
 
 $encode_text = [System.Text.Encoding]::UTF8.GetBytes($PLAIN_TEXT)
 
-curl 127.0.0.1:62007 -Method POST -Body $encode_text
+curl 127.0.0.1:62007 -Method POST -Body $encode_text -UseBasicParsing


### PR DESCRIPTION
不加参数curl请求可以正常发送，但是在Win 10 下会报无法解析返回的错误。