### PR TITLE
chore: add dev-firefox command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build-tauri": "tauri build",
     "dev-tauri": "tauri dev",
     "dev-browser-extension": "pnpm vite -c vite.config.chromium.ts",
+    "dev-firefox": "NODE_ENV=development pnpm vite build -c vite.config.firefox.ts --watch",
     "build-browser-extension": "pnpm tsc && make build-browser-extension",
     "clean": "make clean",
     "test": "npx jest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-tauri": "tauri build",
     "dev-tauri": "tauri dev",
     "dev-browser-extension": "pnpm vite -c vite.config.chromium.ts",
-    "dev-firefox": "NODE_ENV=development pnpm vite build -c vite.config.firefox.ts --watch",
+    "dev-firefox": "NODE_ENV=development vite build -c vite.config.firefox.ts --watch",
     "build-browser-extension": "pnpm tsc && make build-browser-extension",
     "clean": "make clean",
     "test": "npx jest",


### PR DESCRIPTION
> Yeah, until Firefox supports loading modules from localhost in a content script, you won't be able to use this plugins implementation of dev mode with it. Like the previous comment says, using watch with build is an alternative or developing in Chromium which supports it.

https://github.com/samrum/vite-plugin-web-extension/issues/87