### PR TITLE
pump the version of azure openai service to 2023-05-15 GA in README

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -176,7 +176,7 @@ const API_URL_PATH = `/openai/deployments/${deployName}/completions?api-version=
 
 - resourceName: 你的 Azure OpenAI Service 资源名称。
 - deployName: 你的 Azure OpenAI Service 模型部署名称，更改部署名称以切换模型。
-- api-version: 2023-03-15-preview，或者更新的版本。
+- api-version: 2023-05-15，或者更新的版本。
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ const API_URL_PATH = `/openai/deployments/${deployName}/completions?api-version=
 
 - resourceName: Your Azure OpenAI Service resource name.
 - deployName: Your Azure OpenAI Service model deploy name, you can change your model here.
-- api-version: 2023-03-15-preview, or newer.
+- api-version: 2023-05-15, or newer.
 
 # License
 


### PR DESCRIPTION
Azure OpenAI Service chat is GA now.

https://learn.microsoft.com/zh-cn/azure/cognitive-services/openai/whats-new#azure-openai-chat-completion-general-availability-ga