### PR TITLE
[Fix] 主题颜色初始化闪烁

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-window": "^1.8.9",
     "styletron-engine-atomic": "^1.5.0",
     "styletron-react": "^6.1.0",
+    "swr": "^2.1.5",
     "tauri-plugin-autostart-api": "github:tauri-apps/tauri-plugin-autostart",
     "tesseract.js": "^4.0.2",
     "underscore": "^1.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ dependencies:
   styletron-react:
     specifier: ^6.1.0
     version: 6.1.0(react@18.2.0)
+  swr:
+    specifier: ^2.1.5
+    version: 2.1.5(react@18.2.0)
   tauri-plugin-autostart-api:
     specifier: github:tauri-apps/tauri-plugin-autostart
     version: github.com/tauri-apps/tauri-plugin-autostart/8d2706d05568f71eb81a05c3c891db1291c3ca82
@@ -7339,6 +7342,15 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  /swr@2.1.5(react@18.2.0):
+    resolution: {integrity: sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
 
   /symbol-observable@1.2.0:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}

--- a/src/common/components/GlobalSuspense.tsx
+++ b/src/common/components/GlobalSuspense.tsx
@@ -1,0 +1,6 @@
+import { Suspense } from 'react'
+
+export function GlobalSuspense({ children }: { children: React.ReactNode }) {
+    // TODO: a global loading fallback
+    return <Suspense fallback={null}>{children}</Suspense>
+}

--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -33,6 +33,7 @@ import { Slider } from 'baseui-sd/slider'
 import { getUniversalFetch } from '../universal-fetch'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { actionService } from '../services/action'
+import { GlobalSuspense } from './GlobalSuspense'
 
 const langOptions: Value = supportedLanguages.reduce((acc, [id, label]) => {
     return [
@@ -930,7 +931,9 @@ export function Settings({ engine, ...props }: ISettingsProps) {
     return (
         <StyletronProvider value={engine}>
             <BaseProvider theme={theme}>
-                <InnerSettings {...props} />
+                <GlobalSuspense>
+                    <InnerSettings {...props} />
+                </GlobalSuspense>
             </BaseProvider>
         </StyletronProvider>
     )

--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -64,6 +64,7 @@ import Latex from 'react-latex-next'
 import { Markdown } from './Markdown'
 import useResizeObserver from 'use-resize-observer'
 import _ from 'underscore'
+import { GlobalSuspense } from './GlobalSuspense'
 
 const cache = new LRUCache({
     max: 500,
@@ -435,11 +436,15 @@ export function Translator(props: ITranslatorProps) {
 
     return (
         <ErrorBoundary FallbackComponent={ErrorFallback}>
-            <StyletronProvider value={props.engine}>
-                <BaseProvider theme={theme}>
-                    <InnerTranslator {...props} />
-                </BaseProvider>
-            </StyletronProvider>
+            <div>
+                <StyletronProvider value={props.engine}>
+                    <BaseProvider theme={theme}>
+                        <GlobalSuspense>
+                            <InnerTranslator {...props} />
+                        </GlobalSuspense>
+                    </BaseProvider>
+                </StyletronProvider>
+            </div>
         </ErrorBoundary>
     )
 }

--- a/src/common/hooks/useCurrentThemeType.ts
+++ b/src/common/hooks/useCurrentThemeType.ts
@@ -1,33 +1,18 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { BaseThemeType } from '../types'
 import { useThemeDetector } from './useThemeDetector'
 import { useThemeType } from './useThemeType'
 
 export const useCurrentThemeType = (): BaseThemeType => {
-    const { themeType: themeType_ } = useThemeType()
+    const { themeType: themeTypeSetting } = useThemeType()
 
     const systemIsDark = useThemeDetector()
 
-    const [themeType, setThemeType] = useState<BaseThemeType>(
-        (() => {
-            if (themeType_ === 'followTheSystem') {
-                return systemIsDark ? 'dark' : 'light'
-            }
-            return themeType_
-        })()
-    )
-
-    useEffect(() => {
-        if (themeType_ === 'followTheSystem') {
-            if (systemIsDark) {
-                setThemeType('dark')
-            } else {
-                setThemeType('light')
-            }
-        } else {
-            setThemeType(themeType_)
+    const themeType = useMemo(() => {
+        if (themeTypeSetting === 'followTheSystem') {
+            return systemIsDark ? 'dark' : 'light'
         }
-    }, [themeType_, systemIsDark])
-
+        return themeTypeSetting
+    }, [themeTypeSetting, systemIsDark])
     return themeType
 }

--- a/src/common/hooks/useSettings.ts
+++ b/src/common/hooks/useSettings.ts
@@ -1,16 +1,20 @@
-import { useEffect, useState } from 'react'
+import useSWR from 'swr'
+
 import { ISettings } from '../types'
 import { getSettings } from '../utils'
+import { useCallback } from 'react'
 
 export function useSettings() {
-    const [settings, setSettings] = useState<ISettings>()
+    const { data: settings, mutate } = useSWR<ISettings>(['settings', getSettings], getSettings, { suspense: true })
 
-    useEffect(() => {
-        ;(async () => {
-            const settings = await getSettings()
-            setSettings(settings)
-        })()
-    }, [])
+    const setSettings = useCallback(
+        (newSettings: ISettings) => {
+            mutate(newSettings, {
+                optimisticData: newSettings,
+            })
+        },
+        [mutate]
+    )
 
     return {
         settings,

--- a/src/common/hooks/useTheme.ts
+++ b/src/common/hooks/useTheme.ts
@@ -1,14 +1,9 @@
 import { DarkTheme, LightTheme } from 'baseui-sd/themes'
-import { useEffect, useState } from 'react'
 import { useCurrentThemeType } from './useCurrentThemeType'
+import { useMemo } from 'react'
 
 export const useTheme = () => {
     const themeType = useCurrentThemeType()
-    const [theme, setTheme] = useState(themeType === 'light' ? LightTheme : DarkTheme)
-
-    useEffect(() => {
-        setTheme(themeType === 'light' ? LightTheme : DarkTheme)
-    }, [themeType])
-
+    const theme = useMemo(() => (themeType === 'light' ? LightTheme : DarkTheme), [themeType])
     return { theme, themeType }
 }

--- a/src/common/hooks/useThemeDetector.ts
+++ b/src/common/hooks/useThemeDetector.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 export const useThemeDetector = () => {
     const getCurrentTheme = () => window.matchMedia('(prefers-color-scheme: dark)').matches
-    const [isDarkTheme, setIsDarkTheme] = useState(getCurrentTheme())
+    const [isDarkTheme, setIsDarkTheme] = useState(getCurrentTheme)
     const mqListener = useCallback((e: { matches: boolean | ((prevState: boolean) => boolean) }) => {
         setIsDarkTheme(e.matches)
     }, [])

--- a/src/common/hooks/useThemeType.ts
+++ b/src/common/hooks/useThemeType.ts
@@ -1,20 +1,18 @@
-import { useEffect } from 'react'
-import { useGlobalState } from './global'
-import { useSettings } from './useSettings'
+import useSWR from 'swr'
+import { getSettings } from '../utils'
 
 export const useThemeType = () => {
-    const [themeType, setThemeType] = useGlobalState('themeType')
-
-    const { settings } = useSettings()
-
-    useEffect(() => {
-        if (settings?.themeType) {
-            setThemeType(settings.themeType)
-        }
-    }, [setThemeType, settings?.themeType])
+    const { data: themeType, mutate: setThemeType } = useSWR(
+        [getSettings, 'themeType'],
+        async () => {
+            const settings = await getSettings()
+            return settings.themeType
+        },
+        { suspense: true }
+    )
 
     return {
-        themeType,
+        themeType: themeType ?? 'light',
         setThemeType,
     }
 }


### PR DESCRIPTION
Fixes: #761 and remove unnecessary setState

Since `getSettings` is async, I use swr to sync state between react and browser.storage. Use react suspense to prevent showing a init state.

As the asynchronous setting loading process is very fast, it feels like a dedicated loading fallback is not necessary. Currently, I have set the global loading fallback directly to blank.