### PR TITLE
fix: unable to input on macOS 12-

### DIFF
--- a/src/tauri/index.html
+++ b/src/tauri/index.html
@@ -32,6 +32,10 @@
                 user-select: none;
             }
 
+            input, textarea {
+                -webkit-user-select: text;
+            }
+
             .titlebar {
                 height: 30px;
                 background: transparent;


### PR DESCRIPTION
Adds css rule for `input` and `textarea` to fix input issues on macOS 12-. 

this is caused by setting `-webkit-user-select: none`.

related issues: https://github.com/openai-translator/openai-translator/issues/768, https://github.com/openai-translator/openai-translator/issues/767

reference:
1. https://github.com/tauri-apps/tauri/discussions/3541#discussioncomment-2570534
2. https://armno.in.th/blog/css-user-select/