### PR TITLE
ci: fix pnpm install errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install packages
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run type check
         run: pnpm tsc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           cache: 'pnpm'
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm or pnpm depending on which one you use
+        run: pnpm install --no-frozen-lockfile # change this to npm or pnpm depending on which one you use
 
       - name: Change Version
         env:
@@ -122,7 +122,7 @@ jobs:
           cache: 'pnpm'
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm or pnpm depending on which one you use
+        run: pnpm install --no-frozen-lockfile # change this to npm or pnpm depending on which one you use
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -248,7 +248,7 @@ jobs:
         uses: battila7/get-version-action@v2
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build
         run: make build-browser-extension

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -40,7 +40,7 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm or pnpm depending on which one you use
+        run: pnpm install --no-frozen-lockfile # change this to npm or pnpm depending on which one you use
 
       - name: Build Tauri App (MacOS Universal)
         uses: tauri-apps/tauri-action@dev
@@ -86,7 +86,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build
         run: make build-browser-extension

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install packages
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run test
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
-    "react-error-boundary": "^3.1.4",
+    "react-error-boundary": "^4.0.9",
     "react-ga4": "^2.1.0",
     "react-hooks-global-state": "^2.1.0",
     "react-hot-toast": "^2.4.0",


### PR DESCRIPTION
https://github.com/openai-translator/openai-translator/actions/runs/5140208408/jobs/9251451919?pr=797

``` 

ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json

```

closes: #797

https://github.com/openai-translator/openai-translator/pull/797#issuecomment-1571312707