### PR TITLE
fix #895

### DIFF
--- a/src/common/translate.ts
+++ b/src/common/translate.ts
@@ -522,13 +522,13 @@ export async function translate(query: TranslateQuery) {
                 if (!conversationId) {
                     conversationId = resp.conversation_id
                 }
-                const { finish_details: finishDetails } = resp.message
+                const { finish_details: finishDetails } = resp.messages
                 if (finishDetails) {
                     query.onFinish(finishDetails.type)
                     return
                 }
 
-                const { content, author } = resp.message
+                const { content, author } = resp.messages
                 if (author.role === 'assistant') {
                     const targetTxt = content.parts.join('')
                     let textDelta = targetTxt.slice(length)


### PR DESCRIPTION
修复ChatGPT(Web)接口https://chat.openai.com/backend-api/conversation的返回字段message变为messages导致的「TypeError: Cannot destructure property 'finish_details' of 'E.message' as it is undefined.」问题