### PR TITLE
fix: prevent keyboard event propagation during typing

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1540,6 +1540,9 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                                                     : Math.min(Math.max(editableText.split('\n').length, 3), 12)
                                             }
                                             onChange={(e) => setEditableText(e.target.value)}
+                                            onKeyDown={(e) => {
+                                                e.stopPropagation()
+                                            }}
                                             onKeyPress={(e) => {
                                                 if (e.key === 'Enter' && !e.shiftKey) {
                                                     e.preventDefault()


### PR DESCRIPTION
**BEFORE:**

[a2083d20-f210-4418-bda6-aec5903b9868.webm](https://github.com/openai-translator/openai-translator/assets/18044730/fda1a18b-6fed-4e69-809c-eac12bacd376)

----

**AFTER:**

[bb5543c5-96bc-492f-abe7-f75b5751a822.webm](https://github.com/openai-translator/openai-translator/assets/18044730/126f7a8c-34ba-4742-bbe6-0d95051c1ce0)
