### PR TITLE
should not depend on check role behavior, instead check the content

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -956,7 +956,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                         setIsNotLogin(statusCode === 401 || statusCode === 403)
                     },
                     onMessage: (message) => {
-                        if (message.role) {
+                        if (!message.content) {
                             return
                         }
                         setIsWordMode(message.isWordMode)

--- a/src/common/components/Vocabulary.tsx
+++ b/src/common/components/Vocabulary.tsx
@@ -271,7 +271,7 @@ const Vocabulary = (props: IVocabularyProps) => {
                 text: str,
                 articlePrompt: prompt || '',
                 onMessage: (message) => {
-                    if (message.role) {
+                    if (!message.content) {
                         return
                     }
                     setArticle((e) => {


### PR DESCRIPTION
why submit this PR?

I hope the sse handle logic be more compatible

I was writing a proxy adapter ( which proxy and emulate the openai api) to help people can use different backend (for example it can allow people use `Claude2`) in `openai-translator`. in the api, it emulate the response just like openai api.
all things works and `openai-translator` did not report any erorr. but I got the problem is, none of the translated results shown in the UI. it took me hours to debug this issue, finally I found the problem.

```javascript
                    if (message.role) {
                        return
                    }
```

the code just check if `message.role` not empty, then drop the result content.

this code assume that, when `message.role` present, the content must be empty.

I looks the official python client sdk, there's no such code.

and also I looked the docs: https://platform.openai.com/docs/api-reference/chat/streaming#choices-delta-role

It also does not define this behavior.

btw:
openai-translator is awesome, and I like it. thanks all guys for the great work.
