### PR TITLE
fix: including media framework on appimage to resolve audio not play issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
 
       - name: install dependencies (mac only)
         if: matrix.config.os == 'macos-latest'

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,6 +66,9 @@
       ],
       "identifier": "xyz.yetone.apps.openai-translator",
       "longDescription": "",
+      "appimage": {
+        "bundleMediaFramework": true
+      },
       "macOS": {
         "entitlements": null,
         "exceptionDomain": "",


### PR DESCRIPTION
problem: linux appimage, click sound icon, no sound play


fix: including media framework on appimage to resolve audio not play issue

ref and thanks to: https://github.com/SlimeVR/SlimeVR-Server/pull/650

and as https://tauri.app/v1/guides/building/linux/#appimage

> CAUTION
> If your app plays audio/video you need to enable tauri.conf.json > tauri > bundle > appimage > bundleMediaFramework. This will increase the size of the AppImage bundle to include additional gstreamer files needed for media playback. This flag is currently only supported on Ubuntu build systems.