### PR TITLE
feat: read aloud the selected words from sentence in textarea automatically

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -745,6 +745,30 @@ function SelectInputElementsCheckbox({ value, onChange, onBlur }: SelectInputEle
         />
     )
 }
+
+interface ReadSelectedWordsFromInputElementsProps {
+    value?: boolean
+    onChange?: (value: boolean) => void
+    onBlur?: () => void
+}
+
+function ReadSelectedWordsFromInputElementsCheckbox({
+    value,
+    onChange,
+    onBlur,
+}: ReadSelectedWordsFromInputElementsProps) {
+    return (
+        <Checkbox
+            checkmarkType='toggle_round'
+            checked={value}
+            onChange={(e) => {
+                onChange?.(e.target.checked)
+                onBlur?.()
+            }}
+        />
+    )
+}
+
 interface RunAtStartupCheckboxProps {
     value?: boolean
     onChange?: (value: boolean) => void
@@ -987,6 +1011,7 @@ export function InnerSettings({ onSave }: IInnerSettingsProps) {
         i18n: utils.defaulti18n,
         restorePreviousPosition: false,
         selectInputElementsText: utils.defaultSelectInputElementsText,
+        readSelectedWordsFromInputElementsText: utils.defaultReadSelectedWordsFromInputElementsText,
         runAtStartup: false,
         writingTargetLanguage: utils.defaultWritingTargetLanguage,
     })
@@ -1277,6 +1302,9 @@ export function InnerSettings({ onSave }: IInnerSettingsProps) {
                 </FormItem>
                 <FormItem name='selectInputElementsText' label={t('Word selection in input')}>
                     <SelectInputElementsCheckbox onBlur={onBlur} />
+                </FormItem>
+                <FormItem name='readSelectedWordsFromInputElementsText' label={t('Read the selected words in input')}>
+                    <ReadSelectedWordsFromInputElementsCheckbox onBlur={onBlur} />
                 </FormItem>
                 {isTauri && (
                     <FormItem name='runAtStartup' label={t('Run at startup')}>

--- a/src/common/i18n/locales/en/translation.json
+++ b/src/common/i18n/locales/en/translation.json
@@ -16,6 +16,7 @@
   "Default translate mode": "Default translate mode",
   "Auto Translate": "Auto Translate",
   "Word selection in input": "Enable word selection for lookup in the input field",
+  "Read the selected words in input": "Read word selection from the input field automatically",
   "Always show icons": "Always show icons",
   "Default target language": "Default target language",
   "Theme": "Theme",

--- a/src/common/i18n/locales/ja/translation.json
+++ b/src/common/i18n/locales/ja/translation.json
@@ -16,6 +16,7 @@
   "Default translate mode": "デフォルトの翻訳モード",
   "Auto Translate": "自動翻訳",
   "Word selection in input": "テキスト入力エレメント内で選択可能",
+  "Read the selected words in input": "入力ボックスで選択された単語を読み上げる",
   "Always show icons": "常にアイコンを表示",
   "Default target language": "デフォルトのターゲット言語",
   "Theme": "テーマ",

--- a/src/common/i18n/locales/th/translation.json
+++ b/src/common/i18n/locales/th/translation.json
@@ -16,6 +16,7 @@
   "Default translate mode": "โหมดการแปลเริ่มต้น",
   "Auto Translate": "แปลอัตโนมัติ",
   "Word selection in input": "สามารช์เลือกข้อมูลในเว็บไผต์ข้อมูลการใส่ข้อมูล",
+  "Read the selected words in input": "อ่านคำที่ถูกเลือกในกล่องข้อความออกเสียง",
   "Default target language": "ภาษาเป้าหมายเริ่มต้น",
   "Theme": "ธีม",
   "i18n": "ภาษา",

--- a/src/common/i18n/locales/zh-Hans/translation.json
+++ b/src/common/i18n/locales/zh-Hans/translation.json
@@ -16,6 +16,7 @@
   "Default translate mode": "默认翻译模式",
   "Auto Translate": "自动翻译",
   "Word selection in input": "输入框划词",
+  "Read the selected words in input": "朗读输入框中选中的单词",
   "Always show icons": "始终显示图标",
   "Default target language": "默认目标语言",
   "Theme": "主题",

--- a/src/common/i18n/locales/zh-Hant/translation.json
+++ b/src/common/i18n/locales/zh-Hant/translation.json
@@ -16,6 +16,7 @@
   "Default translate mode": "預設翻譯模式",
   "Auto Translate": "自動翻譯",
   "Word selection in input": "輸入框內應選",
+  "Read the selected words in input": "朗讀輸入框中選中的單詞",
   "Always show icons": "總是顯示圖示",
   "Default target language": "預設目標語言",
   "Theme": "主題",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -71,6 +71,7 @@ export interface ISettings {
     }
     restorePreviousPosition?: boolean
     selectInputElementsText?: boolean
+    readSelectedWordsFromInputElementsText?: boolean
     runAtStartup?: boolean
     disableCollectingStatistics?: boolean
     allowUsingClipboardWhenSelectedTextNotAvailable?: boolean

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -15,6 +15,7 @@ export const defaultAutoTranslate = false
 export const defaultTargetLanguage = 'zh-Hans'
 export const defaultWritingTargetLanguage = 'en'
 export const defaultSelectInputElementsText = true
+export const defaultReadSelectedWordsFromInputElementsText = false
 export const defaulti18n = 'en'
 
 export async function getApiKey(): Promise<string> {
@@ -45,6 +46,7 @@ const settingKeys: Record<keyof ISettings, number> = {
     restorePreviousPosition: 1,
     runAtStartup: 1,
     selectInputElementsText: 1,
+    readSelectedWordsFromInputElementsText: 1,
     disableCollectingStatistics: 1,
     allowUsingClipboardWhenSelectedTextNotAvailable: 1,
     pinned: 1,
@@ -94,6 +96,12 @@ export async function getSettings(): Promise<ISettings> {
     }
     if (settings.selectInputElementsText === undefined || settings.selectInputElementsText === null) {
         settings.selectInputElementsText = defaultSelectInputElementsText
+    }
+    if (
+        settings.readSelectedWordsFromInputElementsText === undefined ||
+        settings.readSelectedWordsFromInputElementsText === null
+    ) {
+        settings.readSelectedWordsFromInputElementsText = defaultReadSelectedWordsFromInputElementsText
     }
     if (!settings.themeType) {
         settings.themeType = 'followTheSystem'


### PR DESCRIPTION
Add a new option, default state is off. 

![image](https://github.com/openai-translator/openai-translator/assets/39730824/6d0e789d-b1c2-4ec9-865e-8b3aefe301af)

After turning on, it will automatically read aloud the selected words:

 ![image](https://github.com/openai-translator/openai-translator/assets/39730824/0f472d3d-4fe5-4ff3-924d-5bf2d9850834)
