### PR TITLE
use manifest v2 to support firefox

### DIFF
--- a/src/browser-extension/manifest.ts
+++ b/src/browser-extension/manifest.ts
@@ -1,71 +1,119 @@
 /* eslint-disable camelcase */
 import { version } from '../../package.json'
 
-export function getManifest(browser: 'firefox' | 'chromium') {
-    const manifest: chrome.runtime.Manifest = {
-        manifest_version: 3,
+export function getManifest(browser: 'firefox' | 'chromium'): chrome.runtime.Manifest {
+    if (browser === 'chromium') {
+        return {
+            manifest_version: 3,
 
-        name: 'OpenAI Translator',
-        description: `OpenAI-Translator is a browser extension that uses the ChatGPT API for translation.`,
-        version: version,
+            name: 'OpenAI Translator',
+            description: `OpenAI-Translator is a browser extension that uses the ChatGPT API for translation.`,
+            version: version,
 
-        icons: {
-            '16': 'icon.png',
-            '32': 'icon.png',
-            '48': 'icon.png',
-            '128': 'icon.png',
-        },
-
-        options_ui: {
-            page: 'src/browser-extension/options/index.html',
-            open_in_tab: true,
-        },
-
-        action: {
-            default_icon: 'icon.png',
-            default_popup: 'src/browser-extension/popup/index.html',
-        },
-
-        content_scripts: [
-            {
-                matches: ['<all_urls>'],
-                all_frames: true,
-                js: ['src/browser-extension/content_script/index.tsx'],
+            icons: {
+                '16': 'icon.png',
+                '32': 'icon.png',
+                '48': 'icon.png',
+                '128': 'icon.png',
             },
-        ],
 
-        background: {
-            service_worker: 'src/browser-extension/background/index.ts',
-        },
+            options_ui: {
+                page: 'src/browser-extension/options/index.html',
+                open_in_tab: true,
+            },
 
-        permissions: ['storage', 'contextMenus'],
+            action: {
+                default_icon: 'icon.png',
+                default_popup: 'src/browser-extension/popup/index.html',
+            },
 
-        commands: {
-            'open-popup': {
-                suggested_key: {
-                    default: 'Ctrl+Shift+Y',
-                    mac: 'Command+Shift+Y',
+            content_scripts: [
+                {
+                    matches: ['<all_urls>'],
+                    all_frames: true,
+                    js: ['src/browser-extension/content_script/index.tsx'],
                 },
-                description: 'Open the popup',
+            ],
+
+            background: {
+                service_worker: 'src/browser-extension/background/index.ts',
             },
-        },
 
-        host_permissions: [
-            'https://*.openai.com/',
-            'https://*.openai.azure.com/',
-            'https://*.ingest.sentry.io/',
-            '*://speech.platform.bing.com/',
-            'https://*.googletagmanager.com/',
-            'https://*.google-analytics.com/',
-        ],
-    }
+            permissions: ['storage', 'contextMenus'],
 
-    if (browser === 'firefox') {
-        manifest.browser_specific_settings = {
-            gecko: {
-                id: 'openaitranslator@gmail.com',
+            commands: {
+                'open-popup': {
+                    suggested_key: {
+                        default: 'Ctrl+Shift+Y',
+                        mac: 'Command+Shift+Y',
+                    },
+                    description: 'Open the popup',
+                },
+            },
+
+            host_permissions: [
+                'https://*.openai.com/',
+                'https://*.openai.azure.com/',
+                'https://*.ingest.sentry.io/',
+                '*://speech.platform.bing.com/',
+                'https://*.googletagmanager.com/',
+                'https://*.google-analytics.com/',
+            ],
+        }
+    } else {
+        return {
+            manifest_version: 2,
+
+            name: 'OpenAI Translator',
+            description: `OpenAI-Translator is a browser extension that uses the ChatGPT API for translation.`,
+            version: version,
+
+            icons: {
+                '16': 'icon.png',
+                '32': 'icon.png',
+                '48': 'icon.png',
+                '128': 'icon.png',
+            },
+
+            options_ui: {
+                page: 'src/browser-extension/options/index.html',
+                open_in_tab: true,
+            },
+
+            browser_action: {
+                default_icon: 'icon.png',
+                default_popup: 'src/browser-extension/popup/index.html',
+            },
+
+            content_scripts: [
+                {
+                    matches: ['<all_urls>'],
+                    all_frames: true,
+                    js: ['src/browser-extension/content_script/index.tsx'],
+                },
+            ],
+
+            background: {
+                scripts: ['src/browser-extension/background/index.ts'],
+            },
+
+            permissions: ['storage', 'contextMenus', '<all_urls>'],
+
+            commands: {
+                'open-popup': {
+                    suggested_key: {
+                        default: 'Ctrl+Shift+Y',
+                        mac: 'Command+Shift+Y',
+                    },
+                    description: 'Open the popup',
+                },
+            },
+
+            browser_specific_settings: {
+                gecko: {
+                    id: 'openaitranslator@gmail.com',
+                },
             },
         }
     }
-    return manifest
 }


### PR DESCRIPTION
Considering that Firefox does not yet support Manifest V3, I propose that we might need a version that temporarily supports Firefox. Here, I have created a temporary version using Manifest V2, which should work under Firefox.

I believe this version should not be considered as an official branch, but rather exist as a hotfix.

Additionally, if we aim to release the Firefox add-on, there are potential issues that might be encountered:

1. Icons may need to be squared.
2. The 'tiktoken' consumes a large amount of space, exceeding Firefox's 4MB limit per file, which might necessitate temporarily disabling this feature.

I am more than willing to assist in resolving the above-mentioned issues to facilitate the release of a usable Firefox plugin version.

----

既然Firefox还不支持manifest v3的service worker，那么我们是否要有一个版本来暂时支持Firefox？这里，我用manifest v2编写了一个临时的版本，它应该可以在firefox下工作。

我想这个版本不应该被作为正式分支，而是作为一个hotfix存在。

同时，如果发布firefox附加组件，可能遇到的其他问题：

1. 图标需要改为正方形
3. tiktoken占用了大量的空间，超过Firefox单个文件的4MB限制，可能需要暂时禁用该功能

我也可以修复上面的问题，以帮助发布一个可用的firefox插件版本。