### PR TITLE
chore: add latest gpt-3.5-turbo-1106 model option

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -544,6 +544,7 @@ interface APIModelOption {
 }
 
 const openAIModelOptions: APIModelOption[] = [
+    { label: 'gpt-3.5-turbo-1106', id: 'gpt-3.5-turbo-1106' },
     { label: 'gpt-3.5-turbo', id: 'gpt-3.5-turbo' },
     { label: 'gpt-3.5-turbo-0613', id: 'gpt-3.5-turbo-0613' },
     { label: 'gpt-3.5-turbo-0301', id: 'gpt-3.5-turbo-0301' },

--- a/src/common/token.ts
+++ b/src/common/token.ts
@@ -51,6 +51,7 @@ const tiktokenModels = new Set([
     'gpt-4-32k',
     'gpt-4-32k-0314',
     'gpt-4-32k-0613',
+    'gpt-3.5-turbo-1106',
     'gpt-3.5-turbo',
     'gpt-3.5-turbo-0301',
     'gpt-3.5-turbo-0613',

--- a/src/common/translate.ts
+++ b/src/common/translate.ts
@@ -11,6 +11,7 @@ import { codeBlock, oneLine, oneLineTrim } from 'common-tags'
 export type TranslateMode = 'translate' | 'polishing' | 'summarize' | 'analyze' | 'explain-code' | 'big-bang'
 export type Provider = 'OpenAI' | 'ChatGPT' | 'Azure'
 export type APIModel =
+    | 'gpt-3.5-turbo-1106'
     | 'gpt-3.5-turbo'
     | 'gpt-3.5-turbo-0301'
     | 'gpt-3.5-turbo-0613'


### PR DESCRIPTION
## Description
Currently, 'openai-translator' does not support the select on the latest gpt-3.5 model "gpt-3.5-turbo-1106", see [this GPT-3.5 model list](https://platform.openai.com/docs/models/gpt-3-5) for more details.

Per my own experience on these gpt-3.5 models, "gpt-3.5-turbo-1106" outperform "gpt-3.5-turbo" on both speed and accuracy aspects. Hence I want to enable the choice of this model on settings page.