### PR TITLE
feat: support about:blank iframe

### DIFF
--- a/src/browser-extension/manifest.ts
+++ b/src/browser-extension/manifest.ts
@@ -30,6 +30,7 @@ export function getManifest(browser: 'firefox' | 'chromium') {
             {
                 matches: ['<all_urls>'],
                 all_frames: true,
+                match_about_blank: true,
                 js: ['src/browser-extension/content_script/index.tsx'],
             },
         ],


### PR DESCRIPTION
部分网站使用了空网址 + srcdoc 的方式展示内容，该 PR 对该情形增加了兼容