### PR TITLE
fix: use async to create windows and avoid deadlock on Windows as the tauri document said

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,13 +23,13 @@ use tauri_plugin_autostart::MacosLauncher;
 
 use crate::config::{clear_config_cache, get_config_content};
 use crate::lang::detect_lang;
-use crate::ocr::ocr;
 use crate::fetch::fetch_stream;
-use crate::writing::{writing, write_to_input, finish_writing};
+use crate::ocr::ocr_command;
+use crate::writing::{writing_command, write_to_input, finish_writing};
 use crate::windows::{
-    get_main_window_always_on_top, set_main_window_always_on_top, show_action_manager_window,
-    show_main_window_with_selected_text, MAIN_WIN_NAME,
-    show_updater_window, close_updater_window,
+    get_main_window_always_on_top, show_action_manager_window,
+    show_main_window_with_selected_text_command, MAIN_WIN_NAME,
+    show_updater_window, close_updater_window, show_main_window_command,
 };
 
 use mouce::Mouse;
@@ -375,16 +375,14 @@ fn main() {
             get_update_result,
             get_config_content,
             clear_config_cache,
-            windows::show_main_window_command,
-            show_main_window_with_selected_text,
+            show_main_window_command,
+            show_main_window_with_selected_text_command,
             show_action_manager_window,
-            show_updater_window,
             close_updater_window,
             get_main_window_always_on_top,
-            set_main_window_always_on_top,
-            ocr,
+            ocr_command,
             fetch_stream,
-            writing,
+            writing_command,
             write_to_input,
             finish_writing,
             detect_lang,

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -40,6 +40,10 @@ pub fn do_ocr() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tauri::command]
+pub fn ocr_command() {
+    ocr();
+}
+
 pub fn ocr() {
     do_ocr().unwrap();
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -26,7 +26,6 @@ pub fn get_mouse_location() -> Result<(i32, i32), String> {
     }
 }
 
-#[tauri::command]
 pub fn set_main_window_always_on_top() -> bool {
     let handle = APP_HANDLE.get().unwrap();
     let window = handle.get_window(MAIN_WIN_NAME).unwrap();
@@ -49,7 +48,7 @@ pub fn get_main_window_always_on_top() -> bool {
 }
 
 #[tauri::command]
-pub fn show_main_window_with_selected_text() {
+pub async fn show_main_window_with_selected_text_command() {
     let mut window = show_main_window(false, true, false);
     let mut enigo = Enigo::new();
     let selected_text;
@@ -226,7 +225,7 @@ pub fn build_window(builder: tauri::WindowBuilder) -> tauri::Window {
 }
 
 #[tauri::command]
-pub fn show_main_window_command() {
+pub async fn show_main_window_command() {
     show_main_window(false, false, true);
 }
 
@@ -332,7 +331,7 @@ pub fn get_main_window(center: bool, to_mouse_position: bool, set_focus: bool) -
 }
 
 #[tauri::command]
-pub fn show_action_manager_window() {
+pub async fn show_action_manager_window() {
     let window = get_action_manager_window();
     window.show().unwrap();
 }
@@ -408,7 +407,6 @@ pub fn get_settings_window() -> tauri::Window {
     window
 }
 
-#[tauri::command]
 pub fn show_updater_window() {
     let window = get_updater_window();
     window.show().unwrap();

--- a/src-tauri/src/writing.rs
+++ b/src-tauri/src/writing.rs
@@ -29,7 +29,7 @@ struct IncrementalAction {
 static INCREMENTAL_ACTIONS: Mutex<Vec<IncrementalAction>> = Mutex::new(Vec::new());
 
 #[tauri::command]
-pub fn writing() {
+pub fn writing_command() {
     let is_writing = IS_WRITING.lock();
     if *is_writing {
         return;

--- a/src/tauri/utils.ts
+++ b/src/tauri/utils.ts
@@ -9,7 +9,7 @@ export async function bindHotkey(oldHotKey?: string) {
     const settings = await getSettings()
     if (!settings.hotkey) return
     await register(settings.hotkey, () => {
-        invoke('show_main_window_with_selected_text')
+        invoke('show_main_window_with_selected_text_command')
     }).then(() => {
         console.log('register hotkey success')
     })
@@ -35,7 +35,7 @@ export async function bindOCRHotkey(oldOCRHotKey?: string) {
     const settings = await getSettings()
     if (!settings.ocrHotkey) return
     await register(settings.ocrHotkey, () => {
-        invoke('ocr')
+        invoke('ocr_command')
     }).then(() => {
         console.log('OCR hotkey registered')
     })
@@ -48,7 +48,7 @@ export async function bindWritingHotkey(oldWritingHotKey?: string) {
     const settings = await getSettings()
     if (!settings.writingHotkey) return
     await register(settings.writingHotkey, () => {
-        invoke('writing')
+        invoke('writing_command')
     }).then(() => {
         console.log('writing hotkey registered')
     })


### PR DESCRIPTION
<img width="1021" alt="image" src="https://github.com/openai-translator/openai-translator/assets/1206493/40c63acd-5d0d-43ed-b161-8fa2afe5704b">

https://tauri.app/v1/guides/features/multiwindow/