### PR TITLE
fix(browser-extension): refine header styling

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1380,7 +1380,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                         data-tauri-drag-region
                         style={{
                             cursor: isDesktopApp() ? 'default' : showLogo ? 'move' : 'default',
-                            boxShadow: isScrolledToTop ? undefined : theme.lighting.shadow600,
+                            boxShadow: isDesktopApp() && !isScrolledToTop ? theme.lighting.shadow600 : undefined,
                         }}
                     >
                         {showLogo && <LogoWithText ref={logoWithTextRef} />}


### PR DESCRIPTION
**BEFORE**:
<img width="777" alt="截屏2023-12-08 16 17 45" src="https://github.com/openai-translator/openai-translator/assets/18044730/954223d9-27ae-4730-a349-01521ddfac87">

----

**AFTER**:
![image](https://github.com/openai-translator/openai-translator/assets/18044730/dc811a91-b7df-42a5-b08a-130b4efdc84f)
