### PR TITLE
README: update the Azure OpenAI API URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For details, see [Desktop Clip Extension](./CLIP-EXTENSIONS.md)
 
 ```ts
 const API_URL = `https://${resourceName}.openai.azure.com`
-const API_URL_PATH = `/openai/deployments/${deployName}/completions?api-version=${apiVersion}`
+const API_URL_PATH = `/openai/deployments/${deployName}/chat/completions?api-version=${apiVersion}`
 ```
 
 - resourceName: Your Azure OpenAI Service resource name.


### PR DESCRIPTION
Close #1061.

According to https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-35-models:

> GPT-3.5 Turbo is used with the Chat Completion API. GPT-3.5 Turbo version 0301 can also be used with the Completions API. GPT-3.5 Turbo versions 0613 and 1106 only support the Chat Completions API.

With the previous URL path:

![image](https://github.com/openai-translator/openai-translator/assets/1446531/75563533-b4e3-4622-9cc5-6f097e13d4d9)

After:

![image](https://github.com/openai-translator/openai-translator/assets/1446531/3af6c4c4-3bc0-495d-b045-045cb8fcaae0)
