### PR TITLE
‌feat: ‌Updating the Gemini Engine to support multiple API keys

### DIFF
--- a/src/common/engines/gemini.ts
+++ b/src/common/engines/gemini.ts
@@ -34,7 +34,7 @@ export class Gemini implements IEngine {
 
     async sendMessage(req: IMessageRequest): Promise<void> {
         const settings = await getSettings()
-        const apiKey = settings.geminiAPIKey
+        const apiKey = this.getAPIKey()
         const model = settings.geminiAPIModel
         const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?key=${apiKey}`
         const headers = {
@@ -166,5 +166,12 @@ export class Gemini implements IEngine {
         if (!finished && !hasError) {
             req.onFinished('stop')
         }
+    }
+
+    async getAPIKey(): Promise<string> {
+        const settings = await getSettings()
+        const apiKeys = (settings.geminiAPIKey ?? '').split(',').map((s) => s.trim())
+        const apiKey = apiKeys[Math.floor(Math.random() * apiKeys.length)] ?? ''
+        return apiKey
     }
 }


### PR DESCRIPTION
As the current Gemini API rate limit is 60RPM, this commit support multi API Key rotatio