### PR TITLE
fix: Adjust the criterion for determining a normal end to streaming output.

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1056,7 +1056,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
             }
             const afterTranslate = (reason: string) => {
                 stopLoading()
-                if (reason !== 'stop') {
+                if (reason !== 'stop' && reason !== "eos") {
                     if (reason === 'length' || reason === 'max_tokens') {
                         toast(t('Chars Limited'), {
                             duration: 5000,


### PR DESCRIPTION
When using the Together api, an error is reported at the end of the response, but the content is output in its entirety. After debugging, I found that the Together response ends with `eos` instead of `stop`, which is a normal return. After modifying it, everything works fine.