### PR TITLE
fix: macOS x86_64 version release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
           - os: ubuntu-latest
             arch: x86_64
             rust_target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             rust_target: x86_64-apple-darwin
           - os: macos-latest


### PR DESCRIPTION
Update release.yaml

fix macOS x86_64 version release #1501

[Standard GitHub-hosted runners for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)