### PR TITLE
fix: fix background color issue where it did not extend beyond viewport

### DIFF
--- a/src/browser-extension/options/index.tsx
+++ b/src/browser-extension/options/index.tsx
@@ -18,7 +18,7 @@ const useStyles = createUseStyles({
         display: 'flex',
         justifyContent: 'center',
         backgroundColor: props.theme.colors.backgroundSecondary,
-        height: '100%',
+        minHeight: '100%',
     }),
     container: {
         maxWidth: '768px',


### PR DESCRIPTION
Background color does not extend beyond the viewport height in /src/browser-extension/options/index.html
<img width="1096" alt="image" src="https://github.com/openai-translator/openai-translator/assets/23650440/a681aa98-17db-4a36-9ca4-f886b351c972">
