### PR TITLE
fix: fix the issue where hotkeys were not updated when saved in the settings window

### DIFF
--- a/src/tauri/utils.ts
+++ b/src/tauri/utils.ts
@@ -2,6 +2,7 @@ import { isRegistered, register, unregister } from '@tauri-apps/plugin-global-sh
 import { invoke } from '@tauri-apps/api/core'
 import { getSettings } from '@/common/utils'
 import { sendNotification } from '@tauri-apps/plugin-notification'
+import { ISettings } from '@/common/types'
 
 const modifierKeys = [
     'OPTION',
@@ -117,4 +118,12 @@ export async function bindWritingHotkey(oldWritingHotKey?: string) {
     }).then(() => {
         console.log('writing hotkey registered')
     })
+}
+
+export function onSettingsSave(oldSettings: ISettings) {
+    invoke('clear_config_cache')
+    bindHotkey(oldSettings.hotkey)
+    bindDisplayWindowHotkey(oldSettings.displayWindowHotkey)
+    bindOCRHotkey(oldSettings.ocrHotkey)
+    bindWritingHotkey(oldSettings.writingHotkey)
 }

--- a/src/tauri/windows/SettingsWindow.tsx
+++ b/src/tauri/windows/SettingsWindow.tsx
@@ -1,10 +1,11 @@
 import { InnerSettings } from '../../common/components/Settings'
 import { Window } from '../components/Window'
+import { onSettingsSave } from '../utils'
 
 export function SettingsWindow() {
     return (
         <Window windowsTitlebarDisableDarkMode>
-            <InnerSettings showFooter />
+            <InnerSettings showFooter onSave={onSettingsSave} />
         </Window>
     )
 }

--- a/src/tauri/windows/TranslatorWindow.tsx
+++ b/src/tauri/windows/TranslatorWindow.tsx
@@ -3,7 +3,7 @@ import { Translator } from '../../common/components/Translator'
 import { Client as Styletron } from 'styletron-engine-atomic'
 import { listen, Event } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
-import { bindDisplayWindowHotkey, bindHotkey, bindOCRHotkey, bindWritingHotkey } from '../utils'
+import { bindDisplayWindowHotkey, bindHotkey, bindOCRHotkey, bindWritingHotkey, onSettingsSave } from '../utils'
 import { v4 as uuidv4 } from 'uuid'
 import { PREFIX } from '../../common/constants'
 import { translate } from '../../common/translate'
@@ -222,13 +222,7 @@ export function TranslatorWindow() {
                 defaultShowSettings
                 editorRows={10}
                 containerStyle={{ paddingTop: settings.enableBackgroundBlur ? '' : '26px' }}
-                onSettingsSave={(oldSettings) => {
-                    invoke('clear_config_cache')
-                    bindHotkey(oldSettings.hotkey)
-                    bindDisplayWindowHotkey(oldSettings.displayWindowHotkey)
-                    bindOCRHotkey(oldSettings.ocrHotkey)
-                    bindWritingHotkey(oldSettings.writingHotkey)
-                }}
+                onSettingsSave={onSettingsSave}
                 onSettingsShow={onSettingsShow}
             />
         </Window>


### PR DESCRIPTION
When modifying the settings through the "Settings" menu to access the settings page, the changes are saved but the hotkeys are not rebound. A restart is required for the hotkeys to take effect. 

This PR adds the 'onSave' function in the menu window to keep the functions of the two settings pages consistent.