### PR TITLE
feat: add accelerators for some tray menu items

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::APP_HANDLE;
 
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, specta::Type, tauri_specta::Event)]
+pub struct ConfigUpdatedEvent;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ProxyProtocol {
     HTTP,
@@ -33,6 +36,7 @@ pub struct ProxyConfig {
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     pub hotkey: Option<String>,
+    pub display_window_hotkey: Option<String>,
     pub ocr_hotkey: Option<String>,
     pub writing_hotkey: Option<String>,
     pub writing_newline_hotkey: Option<String>,

--- a/src/common/hooks/usePinned.ts
+++ b/src/common/hooks/usePinned.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import { isTauri } from '../utils'
 import { useGlobalState } from './global'
-import { listen, Event, emit } from '@tauri-apps/api/event'
+import { events } from '@/tauri/bindings'
 
 export function usePinned() {
     const [pinned, setPinned_] = useGlobalState('pinned')
@@ -11,11 +11,13 @@ export function usePinned() {
             return
         }
         let unlisten: () => void | undefined
-        listen('pinned-from-tray', (event: Event<{ pinned: boolean }>) => {
-            setPinned_(event.payload.pinned)
-        }).then((unlistenFn) => {
-            unlisten = unlistenFn
-        })
+        events.pinnedFromTrayEvent
+            .listen((event) => {
+                setPinned_(event.payload.pinned)
+            })
+            .then((unlistenFn) => {
+                unlisten = unlistenFn
+            })
         return () => {
             unlisten?.()
         }
@@ -28,7 +30,7 @@ export function usePinned() {
                 if (!isTauri()) {
                     return next
                 }
-                emit('pinned-from-window', { pinned: next })
+                events.pinnedFromWindowEvent.emit({ pinned: next })
                 return next
             })
         },

--- a/src/tauri/bindings.ts
+++ b/src/tauri/bindings.ts
@@ -62,15 +62,24 @@ export const commands = {
 export const events = __makeEvents__<{
     checkUpdateEvent: CheckUpdateEvent
     checkUpdateResultEvent: CheckUpdateResultEvent
+    pinnedFromWindowEvent: PinnedFromWindowEvent
+    pinnedFromTrayEvent: PinnedFromTrayEvent
+    configUpdatedEvent: ConfigUpdatedEvent
 }>({
     checkUpdateEvent: 'check-update-event',
     checkUpdateResultEvent: 'check-update-result-event',
+    pinnedFromWindowEvent: 'pinned-from-window-event',
+    pinnedFromTrayEvent: 'pinned-from-tray-event',
+    configUpdatedEvent: 'config-updated-event',
 })
 
 /** user-defined types **/
 
 export type CheckUpdateEvent = null
 export type CheckUpdateResultEvent = UpdateResult
+export type ConfigUpdatedEvent = null
+export type PinnedFromTrayEvent = { pinned: boolean }
+export type PinnedFromWindowEvent = { pinned: boolean }
 export type UpdateResult = { version: string; currentVersion: string; body: string | null }
 
 /** tauri-specta globals **/

--- a/src/tauri/utils.ts
+++ b/src/tauri/utils.ts
@@ -1,7 +1,7 @@
 import { isRegistered, register, unregister } from '@tauri-apps/plugin-global-shortcut'
 import { getSettings } from '@/common/utils'
 import { sendNotification } from '@tauri-apps/plugin-notification'
-import { commands } from './bindings'
+import { commands, events } from './bindings'
 import { ISettings } from '@/common/types'
 
 const modifierKeys = [
@@ -121,7 +121,7 @@ export async function bindWritingHotkey(oldWritingHotKey?: string) {
 }
 
 export function onSettingsSave(oldSettings: ISettings) {
-    commands.clearConfigCache()
+    events.configUpdatedEvent.emit()
     bindHotkey(oldSettings.hotkey)
     bindDisplayWindowHotkey(oldSettings.displayWindowHotkey)
     bindOCRHotkey(oldSettings.ocrHotkey)


### PR DESCRIPTION
Added accelerators for some tray menu items to make them more aesthetic and practical.
- `'Settings'` uses the same shortcut(`CmdOrCtrl+,`) as the main window to bring up the settings page
- `'OCR'` and `'Show'` use the shortcuts configured in the settings, and they will update as the settings are updated; if not configured, they will be blank like `'Pin'`
- `'Hide'` and `'Quit'` use predefined shortcuts, which are enabled by default


| Before | After |
| -- | -- |
| ![image](https://github.com/openai-translator/openai-translator/assets/9566166/d67aaa59-4669-40f2-b78e-587578bb785d) | ![image](https://github.com/openai-translator/openai-translator/assets/9566166/956dc144-d3d6-4c3c-b73b-918dd9eba4ae) |