### PR TITLE
fix: reopen window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -523,6 +523,14 @@ fn main() {
 
             api.prevent_close();
         }
+        tauri::RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } => {
+            if !has_visible_windows {
+                windows::show_translator_window(false, false, false);
+            }
+        }
         _ => {}
     });
 }


### PR DESCRIPTION
Relate PRs https://github.com/openai-translator/openai-translator/pull/1474 https://github.com/openai-translator/openai-translator/pull/1524

After #1524, the window can only be reopened from the tray on macOS and not by clicking the dock bar.