### PR TITLE
fix: do not show the translator window if the app runs at startup

### DIFF
--- a/src/common/hooks/useMemoWindow.ts
+++ b/src/common/hooks/useMemoWindow.ts
@@ -9,6 +9,7 @@ const sizeKey = '_size'
 export type WindowMemoProps = {
     size: boolean
     position: boolean
+    show: boolean
 }
 
 /**
@@ -48,13 +49,15 @@ export const useMemoWindow = (props: WindowMemoProps) => {
             } catch (e) {
                 console.error(e)
             } finally {
-                await appWindow.unminimize()
-                await appWindow.setFocus()
-                await appWindow.show()
+                if (props.show) {
+                    await appWindow.unminimize()
+                    await appWindow.setFocus()
+                    await appWindow.show()
+                }
             }
         }
         initWindow()
-    }, [props.position, props.size])
+    }, [props.position, props.size, props.show])
 
     useEffect(() => {
         const appWindow = getCurrent()

--- a/src/tauri/windows/TranslatorWindow.tsx
+++ b/src/tauri/windows/TranslatorWindow.tsx
@@ -67,7 +67,9 @@ export function TranslatorWindow() {
         }
     }, [writingFlag])
 
-    useMemoWindow({ size: true, position: false })
+    const { settings } = useSettings()
+
+    useMemoWindow({ size: true, position: false, show: !settings.runAtStartup })
 
     useEffect(() => {
         setupAnalysis()
@@ -103,8 +105,6 @@ export function TranslatorWindow() {
             unlisten?.()
         }
     }, [])
-
-    const { settings } = useSettings()
 
     useEffect(() => {
         if (!settings?.writingTargetLanguage) {


### PR DESCRIPTION
Fixes: #1572 #1511 