### PR TITLE
feat: fix #1649. Repair the problem of browser extension scripts not load in Chrome and Edge due to CSP restrictions

### DIFF
--- a/vite.config.chromium.ts
+++ b/vite.config.chromium.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         svgr(),
         webExtension({
             manifest: getManifest('chromium'),
+            useDynamicUrlWebAccessibleResources: false,
         }),
     ],
     resolve: {


### PR DESCRIPTION
I can't use the mouse to select text or open extensions in the right-click menu after my browser upgrades version because some problems occurred after the browser was upgraded to version 130. When the `use_dynamic_url` is set to true, the script fails to load.

related issue: 

https://github.com/samrum/vite-plugin-web-extension/issues/144

https://github.com/crxjs/chrome-extension-tools/issues/918