### PR TITLE
fix: fix the issue of being unable to save settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@sentry/react": "^7.61.0",
     "@tauri-apps/api": "2.0.0-beta.9",
     "@tauri-apps/plugin-autostart": "github:tauri-apps/tauri-plugin-autostart#v2",
-    "@tauri-apps/plugin-fs": "github:tauri-apps/tauri-plugin-fs#v2",
+    "@tauri-apps/plugin-fs": "2.0.0-beta.7",
     "@tauri-apps/plugin-global-shortcut": "github:tauri-apps/tauri-plugin-global-shortcut#13c59ded715e231a17d2ce970710cc339757c4b1",
     "@tauri-apps/plugin-http": "github:tauri-apps/tauri-plugin-http#v2",
     "@tauri-apps/plugin-notification": "github:tauri-apps/tauri-plugin-notification#v2",


### PR DESCRIPTION
‌‌Lock the version of `@tauri-apps/plugin-fs` to 2.0.0-beta.7(same version of `tauri-plugin-fs` as in `Cargo.toml`) to fix the issue of being unable to save settings.