### PR TITLE
azure add gpt-4o-mini model

### DIFF
--- a/src/common/engines/azure.ts
+++ b/src/common/engines/azure.ts
@@ -15,6 +15,7 @@ export class Azure extends AbstractOpenAI {
             { name: 'gpt-3.5-turbo-16k-0613', id: 'gpt-3.5-turbo-16k-0613' },
             { name: 'gpt-4', id: 'gpt-4' },
             { name: 'gpt-4o (recommended)', id: 'gpt-4o' },
+            { name: 'gpt-4o-mini', id: 'gpt-4o-mini' },
             { name: 'gpt-4-turbo', id: 'gpt-4-turbo' },
             { name: 'gpt-4-turbo-2024-04-09', id: 'gpt-4-turbo-2024-04-09' },
             { name: 'gpt-4-turbo-preview', id: 'gpt-4-turbo-preview' },


### PR DESCRIPTION
add gpt-4o-mini model only for azure https://github.com/openai-translator/openai-translator/issues/1652

as you said https://github.com/openai-translator/openai-translator/pull/1628#issuecomment-2241501871  , with azure it don't work.