### PR TITLE
fix(workflows): Artifact actions v3 is deprecated

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: build tauri renderer
         run: pnpm build-tauri-renderer
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tauri-renderer
           path: dist/tauri/
@@ -147,7 +147,7 @@ jobs:
           VERSION: "${{ steps.get_version.outputs.version-without-v }}"
         run: make change-version change-package-version
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tauri-renderer
           path: dist/tauri

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -62,7 +62,7 @@ jobs:
           releaseId: test-release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tauri-client-app-artifact
           path: |


### PR DESCRIPTION

[Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). 