### PR TITLE
fix: always use default target language (or English) as target language on automatically-change-target-lang

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -851,11 +851,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
                             isTranslate &&
                             (!stopAutomaticallyChangeTargetLang.current || newSourceLang === targetLang_)
                         ) {
-                            return (
-                                (newSourceLang === 'zh-Hans' || newSourceLang === 'zh-Hant'
-                                    ? 'en'
-                                    : (settings?.defaultTargetLanguage as LangCode | undefined)) ?? 'en'
-                            )
+                            return (settings?.defaultTargetLanguage as LangCode | undefined) ?? 'en'
                         }
                         if (!targetLang_) {
                             if (settings?.defaultTargetLanguage) {


### PR DESCRIPTION
fix: https://github.com/openai-translator/openai-translator/issues/1757