### PR TITLE
Fix: Address potential memory leaks and improve listener management

### DIFF
--- a/src/tauri/windows/TranslatorWindow.tsx
+++ b/src/tauri/windows/TranslatorWindow.tsx
@@ -156,14 +156,19 @@ export function TranslatorWindow() {
     }, [settings.writingTargetLanguage])
 
     useEffect(() => {
-        let unlisten
+        let unlistenFn: (() => void) | undefined
         ;(async () => {
-            unlisten = await listen('show', async () => {
+            // Correctly assign the unlisten function once the promise resolves
+            const unlisten = await listen('show', async () => {
                 const uuid_ = uuidv4().replace(/-/g, '').slice(0, 6)
                 setUUID(uuid_)
             })
-        })()
-        return unlisten
+            unlistenFn = unlisten
+        })() // Self-invoking async function
+
+        return () => {
+            unlistenFn?.() // Call the resolved unlisten function on cleanup
+        }
     }, [])
 
     const { pinned } = usePinned()


### PR DESCRIPTION
This commit includes several changes to address potential memory leaks and improve event listener management in both the browser extension content script and Tauri windows.

Key changes:

1.  **Content Script (`src/browser-extension/content_script/index.tsx`):**
    *   Refactored `hotkeys-js` usage to prevent multiple bindings and allow for dynamic updates by tracking the current hotkey and its handler, and unbinding appropriately.
    *   Refactored global DOM event listeners (`mouseup`, `mousedown`, `touchstart`, `touchend`) and the `browser.runtime.onMessage` listener to be named, top-level functions. Associated shared variables (`mousedownTarget`, `lastMouseEvent`) were moved to the top-level scope. This makes these listeners explicitly removable if future features require dynamic disabling/enabling of content script functionality.

2.  **Tauri Windows (`src/tauri/windows/TranslatorWindow.tsx`):**
    *   Fixed a memory leak where a Tauri event listener (`listen('show', ...)`) was not properly cleaning up due to returning a Promise instead of the unlisten function itself from `useEffect`. The `useEffect` hook was corrected to properly manage the lifecycle of the listener.

3.  **General Analysis:**
    *   Reviewed event listener patterns, `useEffect` cleanup functions, and timer management in the inspected files.
    *   Identified areas in dependencies (e.g., `setupAnalysis`, Tauri hotkey binding utilities) that should also ensure proper resource management, though no direct changes were made to these dependencies in this commit.

These changes aim to improve the robustness of the application against memory leaks by ensuring that listeners are properly unbound and resources are cleaned up.