### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
   <img alt="NebulaGraph Data Intelligence Suite(ngdi)" src="https://user-images.githubusercontent.com/1651790/224081979-d3aa7867-94a6-4a85-a5d7-603e02360cee.png">
 </picture>
 <p align="center">
-    <br> English | <a href="README-CN.md">中文</a>
+    <br> English | <a href="README-CN.md">中文</a> | 
+    <!-- Keep these links. Translations will automatically update with the README. -->
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=de">Deutsch</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=es">Español</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=fr">français</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=ja">日本語</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=ko">한국어</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=pt">Português</a> | 
+    <a href="https://www.readme-i18n.com/openai-translator/openai-translator?lang=ru">Русский</a> | 
 </p>
 <p align="center">
     <em>The translator that does more than just translation - powered by OpenAI.</em>


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian.