### PR TITLE
chore: upgrade artifact actions to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: build tauri renderer
         run: pnpm build-tauri-renderer
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tauri-renderer
           path: dist/tauri/
@@ -147,7 +147,7 @@ jobs:
           VERSION: "${{ steps.get_version.outputs.version-without-v }}"
         run: make change-version change-package-version
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tauri-renderer
           path: dist/tauri

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -62,7 +62,7 @@ jobs:
           releaseId: test-release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tauri-client-app-artifact
           path: |


### PR DESCRIPTION
## Summary
- update GitHub workflows to use artifact actions v4

## Testing
- not run