### PR TITLE
Fix Windows build warnings and HWND mismatch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "whatlang",
- "windows 0.56.0",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,7 +66,7 @@ accessibility-ng = "0.1.6"
 accessibility-sys-ng = "0.1.3"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.56.0", features = [ "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Foundation_Collections", "Globalization", "Storage", "Storage_Streams" ] }
+windows = { version = "0.61.3", features = [ "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Foundation_Collections", "Globalization", "Storage", "Storage_Streams" ] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -180,8 +180,8 @@ fn bind_mouse_hook() {
                 }
                 let mouse_distance =
                     (((x - prev_release_x).pow(2) + (y - prev_release_y).pow(2)) as f64).sqrt();
-                let mut previous_press_time = 0;
-                let mut previous_release_time = 0;
+                let previous_press_time: u128;
+                let previous_release_time: u128;
                 {
                     let previous_press_time_lock = PREVIOUS_PRESS_TIME.lock();
                     let mut previous_release_time_lock = PREVIOUS_RELEASE_TIME.lock();
@@ -360,6 +360,7 @@ fn main() {
 
     let specta_builder_setup = specta_builder.clone();
 
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut app = tauri::Builder::default()
         .plugin(
             tauri_plugin_aptabase::Builder::new("A-US-9856842764")

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -78,7 +78,6 @@ pub fn do_ocr() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(target_os = "windows")]
 pub fn do_ocr_with_cut_file_path(image_file_path: &Path) {
     use windows::core::HSTRING;
-    use windows::Globalization::Language;
     use windows::Graphics::Imaging::BitmapDecoder;
     use windows::Media::Ocr::OcrEngine;
     use windows::Storage::{FileAccessMode, StorageFile};

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -7,7 +7,11 @@ use parking_lot::Mutex;
 #[cfg(target_os = "macos")]
 use std::mem::MaybeUninit;
 use std::{thread, time::Duration};
-use tauri::{path::BaseDirectory, Emitter, Manager};
+#[cfg(target_os = "macos")]
+use tauri::path::BaseDirectory;
+use tauri::Emitter;
+#[cfg(target_os = "macos")]
+use tauri::Manager;
 
 use crate::APP_HANDLE;
 
@@ -30,7 +34,7 @@ pub fn select_all(enigo: &mut Enigo) {
 
 #[allow(dead_code)]
 #[cfg(target_os = "macos")]
-pub fn select_all(enigo: &mut Enigo) {
+pub fn select_all(_enigo: &mut Enigo) {
     let _guard = SELECT_ALL.lock();
 
     let apple_script = APP_HANDLE
@@ -60,7 +64,7 @@ pub fn left_arrow_click(enigo: &mut Enigo, n: usize) {
 }
 
 #[cfg(target_os = "macos")]
-pub fn left_arrow_click(enigo: &mut Enigo, n: usize) {
+pub fn left_arrow_click(_enigo: &mut Enigo, n: usize) {
     let _guard = INPUT_LOCK.lock();
 
     let apple_script = APP_HANDLE
@@ -89,7 +93,7 @@ pub fn right_arrow_click(enigo: &mut Enigo, n: usize) {
 }
 
 #[cfg(target_os = "macos")]
-pub fn right_arrow_click(enigo: &mut Enigo, n: usize) {
+pub fn right_arrow_click(_enigo: &mut Enigo, n: usize) {
     let _guard = INPUT_LOCK.lock();
 
     let apple_script = APP_HANDLE
@@ -118,7 +122,7 @@ pub fn backspace_click(enigo: &mut Enigo, n: usize) {
 }
 
 #[cfg(target_os = "macos")]
-pub fn backspace_click(enigo: &mut Enigo, n: usize) {
+pub fn backspace_click(_enigo: &mut Enigo, n: usize) {
     let _guard = INPUT_LOCK.lock();
 
     let apple_script = APP_HANDLE
@@ -178,7 +182,7 @@ pub fn copy(enigo: &mut Enigo) {
 
 #[allow(dead_code)]
 #[cfg(target_os = "macos")]
-pub fn copy(enigo: &mut Enigo) {
+pub fn copy(_enigo: &mut Enigo) {
     let _guard = COPY_PASTE.lock();
 
     let apple_script = APP_HANDLE
@@ -213,7 +217,7 @@ pub fn paste(enigo: &mut Enigo) {
 
 #[allow(dead_code)]
 #[cfg(target_os = "macos")]
-pub fn paste(enigo: &mut Enigo) {
+pub fn paste(_enigo: &mut Enigo) {
     let _guard = COPY_PASTE.lock();
 
     let apple_script = APP_HANDLE
@@ -300,6 +304,7 @@ pub fn get_selected_text_by_clipboard(
     }
 }
 
+#[allow(dead_code)]
 #[cfg(target_os = "macos")]
 unsafe fn ax_call<F, V>(f: F) -> Result<V, AXError>
 where
@@ -369,38 +374,36 @@ pub fn is_valid_selected_frame() -> Result<bool, Box<dyn std::error::Error>> {
     use core_graphics::geometry::{CGPoint, CGSize};
     use debug_print::debug_println;
 
-    unsafe {
-        match get_selected_text_frame_by_ax() {
-            Ok(selected_frame) => {
-                if selected_frame.size.width == 0.0 && selected_frame.size.height == 0.0 {
-                    debug_println!("Selected frame is empty");
-                    return Ok(true);
-                }
+    match get_selected_text_frame_by_ax() {
+        Ok(selected_frame) => {
+            if selected_frame.size.width == 0.0 && selected_frame.size.height == 0.0 {
+                debug_println!("Selected frame is empty");
+                return Ok(true);
+            }
 
-                let expand_value = 40.0;
-                let origin = CGPoint::new(
-                    selected_frame.origin.x - expand_value,
-                    selected_frame.origin.y - expand_value,
-                );
-                let size = CGSize::new(
-                    selected_frame.size.width + expand_value * 2.0,
-                    selected_frame.size.height + expand_value * 2.0,
-                );
-                let expanded_selected_text_frame = CGRect::new(&origin, &size);
-                let (mouse_x, mouse_y) = get_mouse_location()?;
-                let mouse_position_point = CGPoint::new(mouse_x as f64, mouse_y as f64);
-                debug_println!(
-                    "selected_frame: {:?}, expanded_selected_text_frame: {:?}, mouse_position_point: {:?}",
-                    selected_frame,
-                    expanded_selected_text_frame,
-                    mouse_position_point
-                );
-                Ok(expanded_selected_text_frame.contains(&mouse_position_point))
-            }
-            Err(err) => {
-                debug_println!("get_selected_text_frame_by_ax error: {}", err);
-                Err(err)
-            }
+            let expand_value = 40.0;
+            let origin = CGPoint::new(
+                selected_frame.origin.x - expand_value,
+                selected_frame.origin.y - expand_value,
+            );
+            let size = CGSize::new(
+                selected_frame.size.width + expand_value * 2.0,
+                selected_frame.size.height + expand_value * 2.0,
+            );
+            let expanded_selected_text_frame = CGRect::new(&origin, &size);
+            let (mouse_x, mouse_y) = get_mouse_location()?;
+            let mouse_position_point = CGPoint::new(mouse_x as f64, mouse_y as f64);
+            debug_println!(
+                "selected_frame: {:?}, expanded_selected_text_frame: {:?}, mouse_position_point: {:?}",
+                selected_frame,
+                expanded_selected_text_frame,
+                mouse_position_point
+            );
+            Ok(expanded_selected_text_frame.contains(&mouse_position_point))
+        }
+        Err(err) => {
+            debug_println!("get_selected_text_frame_by_ax error: {}", err);
+            Err(err)
         }
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -20,6 +20,7 @@ pub const SETTINGS_WIN_NAME: &str = "settings";
 pub const ACTION_MANAGER_WIN_NAME: &str = "action_manager";
 pub const UPDATER_WIN_NAME: &str = "updater";
 pub const THUMB_WIN_NAME: &str = "thumb";
+#[cfg(target_os = "windows")]
 pub const SCREENSHOT_WIN_NAME: &str = "screenshot";
 
 fn get_dummy_window() -> tauri::WebviewWindow {
@@ -215,6 +216,7 @@ pub fn get_thumb_window(x: i32, y: i32) -> tauri::WebviewWindow {
         }
         None => {
             debug_println!("Thumb window does not exist");
+            #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
             let mut builder = tauri::WebviewWindowBuilder::new(
                 handle,
                 THUMB_WIN_NAME,
@@ -245,7 +247,7 @@ pub fn get_thumb_window(x: i32, y: i32) -> tauri::WebviewWindow {
                 use windows::Win32::UI::WindowsAndMessaging::{
                     SetWindowLongPtrW, GWL_STYLE, WS_POPUP,
                 };
-                let hwnd: windows::Win32::Foundation::HWND = window.hwnd().unwrap();
+                let hwnd = window.hwnd().unwrap();
                 unsafe {
                     // let mut style = GetWindowLongPtrW(hwnd, GWL_STYLE);
                     // style = style & !(0x00020000 | 0x00010000 | 0x00080000); // WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU
@@ -599,11 +601,13 @@ pub fn get_updater_window() -> tauri::WebviewWindow {
     window
 }
 
+#[cfg(target_os = "windows")]
 pub fn show_screenshot_window() {
     let _ = get_screenshot_window();
     // window.show().unwrap();
 }
 
+#[cfg(target_os = "windows")]
 pub fn get_screenshot_window() -> tauri::WebviewWindow {
     let handle = APP_HANDLE.get().unwrap();
     let current_monitor = get_current_monitor();


### PR DESCRIPTION
## Summary
- align the windows crate version with Tauri to avoid HWND type clashes
- drop unused Windows imports and silence macOS-only parameters
- clean up unused mutable bindings so Windows builds are warning-free

## Testing
- cargo check --all-targets