### PR TITLE
fix: unable to use the Google Gemini API for translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@aptabase/tauri": "^0.4.1",
     "@floating-ui/dom": "^1.5.1",
+    "@google/generative-ai": "^0.24.1",
     "@sentry/react": "^7.61.0",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-autostart": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.5.1
         version: 1.5.1
+      '@google/generative-ai':
+        specifier: ^0.24.1
+        version: 0.24.1
       '@sentry/react':
         specifier: ^7.61.0
         version: 7.61.0(react@18.2.0)
@@ -884,6 +887,10 @@ packages:
 
   '@floating-ui/utils@0.1.1':
     resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
+
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
 
   '@humanwhocodes/config-array@0.11.10':
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
@@ -5179,6 +5186,8 @@ snapshots:
       '@floating-ui/utils': 0.1.1
 
   '@floating-ui/utils@0.1.1': {}
+
+  '@google/generative-ai@0.24.1': {}
 
   '@humanwhocodes/config-array@0.11.10':
     dependencies:

--- a/src/common/engines/gemini.ts
+++ b/src/common/engines/gemini.ts
@@ -1,42 +1,44 @@
 /* eslint-disable camelcase */
-import { urlJoin } from 'url-join-ts'
-import { getUniversalFetch } from '../universal-fetch'
-import { fetchSSE, getSettings } from '../utils'
+import { GoogleGenerativeAI, HarmBlockThreshold, HarmCategory } from '@google/generative-ai'
+import { getSettings } from '../utils'
 import { AbstractEngine } from './abstract-engine'
 import { IMessageRequest, IModel } from './interfaces'
-import qs from 'qs'
 
 const SAFETY_SETTINGS = [
     {
-        category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-        threshold: 'BLOCK_NONE',
+        category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        threshold: HarmBlockThreshold.BLOCK_NONE,
     },
     {
-        category: 'HARM_CATEGORY_HATE_SPEECH',
-        threshold: 'BLOCK_NONE',
+        category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        threshold: HarmBlockThreshold.BLOCK_NONE,
     },
     {
-        category: 'HARM_CATEGORY_HARASSMENT',
-        threshold: 'BLOCK_NONE',
+        category: HarmCategory.HARM_CATEGORY_HARASSMENT,
+        threshold: HarmBlockThreshold.BLOCK_NONE,
     },
     {
-        category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-        threshold: 'BLOCK_NONE',
+        category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold: HarmBlockThreshold.BLOCK_NONE,
     },
 ]
 
 export class Gemini extends AbstractEngine {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async listModels(apiKey: string | undefined): Promise<IModel[]> {
+        // The new SDK does not support listing models in the same way.
+        // This might need to be implemented differently if required,
+        // for now, we can return a hardcoded or empty list.
+        // Keeping old implementation for now as SDK doesn't support it.
         if (!apiKey) {
             return []
         }
         const settings = await getSettings()
         const geminiAPIURL = settings.geminiAPIURL
-        const url =
-            urlJoin(geminiAPIURL, '/v1beta/models') +
-            qs.stringify({ key: apiKey, pageSize: 1000 }, { addQueryPrefix: true })
-        const fetcher = getUniversalFetch()
+        // The SDK doesn't expose a model listing API. We have to do it manually.
+        // It's a known issue: https://github.com/google/generative-ai-js/issues/31
+        const url = `${geminiAPIURL}/v1beta/models?key=${apiKey}&pageSize=1000`
+        const fetcher = fetch
         const resp = await fetcher(url, {
             method: 'GET',
             headers: {
@@ -65,73 +67,55 @@ export class Gemini extends AbstractEngine {
     async sendMessage(req: IMessageRequest): Promise<void> {
         const settings = await getSettings()
         const apiKey = settings.geminiAPIKey
-        const geminiAPIURL = settings.geminiAPIURL
-        const model = await this.getModel()
-        const url =
-            urlJoin(geminiAPIURL, '/v1beta/models/', `${model}:streamGenerateContent`) +
-            qs.stringify({ key: apiKey }, { addQueryPrefix: true })
-        const headers = {
-            'Content-Type': 'application/json',
-            'User-Agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36 Edg/91.0.864.41',
+        if (!apiKey) {
+            req.onError('Gemini API key not set')
+            return
         }
-        const body = {
-            contents: [
-                {
-                    role: 'user',
-                    parts: [
-                        {
-                            text: req.rolePrompt ? req.rolePrompt + '\n\n' + req.commandPrompt : req.commandPrompt,
-                        },
-                    ],
-                },
-            ],
-            safetySettings: SAFETY_SETTINGS,
-        }
+        const modelName = await this.getModel()
 
-        await fetchSSE(url, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(body),
-            signal: req.signal,
-            usePartialArrayJSONParser: true,
-            onMessage: async (msg) => {
-                let resp
-                try {
-                    resp = JSON.parse(msg)
-                } catch (e) {
-                    req.onError(JSON.stringify(e))
-                    return
+        try {
+            const genAI = new GoogleGenerativeAI(apiKey)
+            const model = genAI.getGenerativeModel({
+                model: modelName,
+                safetySettings: SAFETY_SETTINGS,
+            })
+
+            const prompt = req.rolePrompt ? `${req.rolePrompt}\n\n${req.commandPrompt}` : req.commandPrompt
+
+            const result = await model.generateContentStream(prompt)
+
+            const signal = req.signal
+            if (signal) {
+                signal.addEventListener('abort', () => {
+                    // This is a bit of a hack, as the SDK doesn't directly support aborting streams yet.
+                    // We can't truly abort the underlying request, but we can stop processing it.
+                    console.log('Gemini stream aborted')
+                })
+            }
+
+            for await (const chunk of result.stream) {
+                if (signal?.aborted) {
+                    break
                 }
-
-                // Always process text content first
-                const text = resp.candidates?.[0]?.content?.parts?.[0]?.text
-                if (text) {
-                    await req.onMessage({ content: text, role: '' })
+                const chunkText = chunk.text()
+                if (chunkText) {
+                    await req.onMessage({ content: chunkText, role: '' })
                 }
-
-                // Check for a finish reason
-                const finishReason = resp.candidates?.[0]?.finishReason
-
-                // CRUCIAL: Only call onFinished if the reason is abnormal (i.e., NOT "STOP").
-                // A silent end of the stream after "STOP" is the success case.
+                const finishReason = chunk.candidates?.[0]?.finishReason
                 if (finishReason && finishReason !== 'STOP') {
                     req.onFinished(finishReason)
                 }
-            },
-            onError: (err) => {
-                if (err instanceof Error) {
-                    req.onError(err.message)
-                    return
-                }
-                if (typeof err === 'string') {
-                    req.onError(err)
-                    return
-                }
-                // Simplified the rest of the error handling as it was overly complex
-                const errorMessage = JSON.stringify(err)
-                req.onError(errorMessage)
-            },
-        })
+            }
+        } catch (err) {
+            let errorMessage = 'An unknown error occurred'
+            if (err instanceof Error) {
+                errorMessage = err.message
+            } else if (typeof err === 'string') {
+                errorMessage = err
+            } else if (err && typeof err === 'object' && 'message' in err) {
+                errorMessage = String((err as { message: unknown }).message)
+            }
+            req.onError(errorMessage)
+        }
     }
 }


### PR DESCRIPTION
Fix issues: #1754 #1700 

Fixing the issue of being unable to use the Google Gemini API for translation

Solution: Use the official Google-provided library for communication.

Test build:
[chromium.zip](https://github.com/user-attachments/files/22988398/chromium.zip)
