### PR TITLE
fix: unblock windows focus build

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ accessibility-sys-ng = "0.1.3"
 xcb = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.61.3", features = [ "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Foundation_Collections", "Globalization", "Storage", "Storage_Streams" ] }
+windows = { version = "0.61.3", features = [ "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_Foundation", "Graphics_Imaging", "Media_Ocr", "Foundation", "Foundation_Collections", "Globalization", "Storage", "Storage_Streams" ] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/insertion.rs
+++ b/src-tauri/src/insertion.rs
@@ -129,8 +129,8 @@ fn focus_window(window: &ActiveWindow) -> Result<(), String> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
     use windows::Win32::UI::WindowsAndMessaging::{
-        AttachThreadInput, BringWindowToTop, GetForegroundWindow, GetWindowThreadProcessId,
-        IsIconic, SetForegroundWindow, ShowWindow, SW_RESTORE,
+        BringWindowToTop, GetForegroundWindow, GetWindowThreadProcessId, IsIconic,
+        SetForegroundWindow, ShowWindow, SW_RESTORE,
     };
 
     let hwnd = parse_hwnd(&window.window_id)?;


### PR DESCRIPTION
## Summary
- enable Win32_System_Threading when targeting Windows so AttachThreadInput is available
- remove the incorrect UI namespace import for AttachThreadInput

## Testing
- not run (not on Windows)