### PR TITLE
Fix textarea highlight lag when idle

### DIFF
--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -603,7 +603,7 @@ function InnerTranslator(props: IInnerTranslatorProps) {
         if (!editor) {
             return undefined
         }
-        highlightRef.current = new HighlightInTextarea(editor, { highlight: '' })
+        highlightRef.current = new HighlightInTextarea(editor, { highlight: [] })
         if (props.autoFocus) {
             editor.focus()
         }

--- a/src/common/highlight-in-textarea/index.ts
+++ b/src/common/highlight-in-textarea/index.ts
@@ -148,6 +148,12 @@ export class HighlightInTextarea {
     }
 
     public handleInput() {
+        if (!this.hasActiveHighlight()) {
+            if (this.highlights) {
+                this.highlights.innerHTML = ''
+            }
+            return
+        }
         const input = this.el?.value
         const ranges = this.getRanges(input, this.highlight?.highlight ?? null)
         const unstaggeredRanges = this.removeStaggeredRanges(ranges)
@@ -394,5 +400,19 @@ export class HighlightInTextarea {
         }
         this.container.parentElement?.replaceChild(this.el, this.container)
         this.el?.classList.remove(this.ID + '-content', this.ID + '-input')
+    }
+
+    private hasActiveHighlight(): boolean {
+        const highlight = this.highlight?.highlight
+        if (!highlight) {
+            return false
+        }
+        if (Array.isArray(highlight)) {
+            return highlight.length > 0
+        }
+        if (typeof highlight === 'string') {
+            return highlight.trim().length > 0
+        }
+        return true
     }
 }


### PR DESCRIPTION
## Summary
- skip highlight rendering when no highlight is active
- initialize translator highlight state with an empty array to avoid redundant work

## Testing
- pnpm lint