### PR TITLE
chore: update app identifiers to openai namespace

### DIFF
--- a/clip-extensions/popclip/Config.plist
+++ b/clip-extensions/popclip/Config.plist
@@ -25,7 +25,7 @@
         <key>Extension Description</key>
         <string>Translate text with NextAI Translator.</string>
         <key>Extension Identifier</key>
-        <string>xyz.yetone.apps.nextai-translator.clip-extensions.popclip</string>
+        <string>xyz.yetone.apps.openai-translator.clip-extensions.popclip</string>
         <key>Extension Image File</key>
         <string>nextai-translator.png</string>
         <key>Extension Name</key>

--- a/clip-extensions/snipdo/nextai-translator.json
+++ b/clip-extensions/snipdo/nextai-translator.json
@@ -1,6 +1,6 @@
 {
     "name": "NextAI Translator",
-    "identifier": "xyz.yetone.apps.nextai-translator.clip-extensions.snipdo",
+    "identifier": "xyz.yetone.apps.openai-translator.clip-extensions.snipdo",
     "icon": "icon.png",
     "actions": [
         {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -95,11 +95,11 @@ pub fn get_config_content() -> String {
 pub fn get_config_content_by_app(app: &AppHandle) -> Result<String, String> {
     let app_paths = app.path();
     let app_config_dir = app_paths
-        .resolve("xyz.yetone.apps.nextai-translator", BaseDirectory::Config)
+        .resolve("xyz.yetone.apps.openai-translator", BaseDirectory::Config)
         .unwrap();
     if !app_config_dir.exists() {
         let old_config_dir = app_paths
-            .resolve("xyz.yetone.apps.openai-translator", BaseDirectory::Config)
+            .resolve("xyz.yetone.apps.nextai-translator", BaseDirectory::Config)
             .unwrap();
         if old_config_dir.exists() {
             if std::fs::rename(&old_config_dir, &app_config_dir).is_err() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "productName": "NextAI Translator",
   "version": "0.1.0",
-  "identifier": "xyz.yetone.apps.nextai-translator",
+  "identifier": "xyz.yetone.apps.openai-translator",
   "build": {
     "beforeDevCommand": "pnpm dev-tauri-renderer",
     "devUrl": "http://localhost:3333",


### PR DESCRIPTION
## Summary
- update the desktop and extension identifiers to the openai namespace
- add migration logic so legacy nextai configs move to the new path
- align bundled clip extensions with the new identifier

## Testing
- not run (not needed)