### PR TITLE
fix: prevent clipboard IPC from overriding hotkey selection

### DIFF
--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -143,6 +143,7 @@ pub async fn show_translator_window_with_selected_text_command() {
     let window = show_translator_window(false, true, true);
 
     if !selected_text.trim().is_empty() {
+        crate::mark_selected_text_hotkey_invoked();
         utils::send_text(selected_text);
     }
 


### PR DESCRIPTION
## Summary
- track when the Windows hotkey successfully injects selected text
- ignore clipboard IPC requests for a short window so they cannot overwrite that text
- add debug logging so we know when the suppression was triggered

## Testing
- Not run (Windows-specific; no Windows runner in this environment)
