### PR TITLE
fix incorrect sock filename

### DIFF
--- a/clip-extensions/popclip/nextai-translator.sh
+++ b/clip-extensions/popclip/nextai-translator.sh
@@ -1,5 +1,5 @@
 send_text() {
-    curl -d "$POPCLIP_TEXT" --unix-socket /tmp/nextai-translator.sock http://nextai-translator
+    curl -d "$POPCLIP_TEXT" --unix-socket /tmp/openai-translator.sock http://nextai-translator
 }
 
 if ! send_text; then


### PR DESCRIPTION
Popclip extension doesn't work as it use the wrong sock filename. 

The socke filename is still named as `openai-translator.sock` not `nextai-translator.sock`