### PR TITLE
fix(openai): fix reasoning_effort compatibility for different model s…

### DIFF
--- a/src/common/engines/abstract-openai.ts
+++ b/src/common/engines/abstract-openai.ts
@@ -131,8 +131,9 @@ export abstract class AbstractOpenAI extends AbstractEngine {
             // We should check if the settings.apiURLPath is match `/deployments/{deployment-id}/chat/completions`.
             // If not, we should use the legacy parameters.
             if (req.rolePrompt) {
-                body['prompt'] =
-                    `<|im_start|>user\n${req.rolePrompt}\n\n${req.commandPrompt}\n<|im_end|>\n<|im_start|>assistant\n`
+                body[
+                    'prompt'
+                ] = `<|im_start|>user\n${req.rolePrompt}\n\n${req.commandPrompt}\n<|im_end|>\n<|im_start|>assistant\n`
             } else {
                 body['prompt'] = `<|im_start|>user\n${req.commandPrompt}\n<|im_end|>\n<|im_start|>assistant\n`
             }


### PR DESCRIPTION
fix https://github.com/nextai-translator/nextai-translator/issues/1841

修复原来判断逻辑中的错误

- o 系列早期思考模型只支持 `low` / `medium` / `high`，不支持 `minimal`
- 将 `minimal` 推理努力限定于 gpt-5 及其思考变体，排除了不支持思考的 `-chat` 变体和只支持 `high` 的 `-pro` 变体
- gpt-5.1 不支持 `minimal`，且默认行为即是使用 `reasoing.effort: none`。考虑未来的模型很可能也是如此，因此不传递推理努力参数以最大兼容。gpt-5.1 也不支持 `frequency_penalty` 和 `presence_penalty`
- 为 gpt-3.5 和 gpt-4 模型使用传统标准参数