### PR TITLE
fix: replace unwrap/expect with proper error handling in OCR module

### DIFF
--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -187,14 +187,17 @@ pub fn do_ocr() -> Result<(), Box<dyn std::error::Error>> {
         rel_path = "resources/bin/ocr_apple".to_string();
     }
 
-    let app = APP_HANDLE
-        .get()
-        .ok_or("APP_HANDLE not initialized")?;
+    let app = APP_HANDLE.get().ok_or("APP_HANDLE not initialized")?;
 
     let bin_path = app
         .path()
         .resolve(&rel_path, BaseDirectory::Resource)
-        .map_err(|e| format!("Failed to resolve ocr binary resource '{}': {:?}", rel_path, e))?;
+        .map_err(|e| {
+            format!(
+                "Failed to resolve ocr binary resource '{}': {:?}",
+                rel_path, e
+            )
+        })?;
 
     if !bin_path.exists() {
         return Err(format!(


### PR DESCRIPTION
## 问题描述 / Problem Description

OCR 功能在生产环境中会 panic，但在开发环境中不会。这是因为代码中大量使用了 `unwrap()` 和 `expect()`，当遇到错误时会直接导致程序崩溃。

## 根本原因 / Root Cause

1. **`ocr()` 函数**：直接调用 `do_ocr().unwrap()`，任何错误都会导致 panic
2. **macOS `do_ocr()`**：使用 `expect()` 处理资源路径解析和二进制执行
3. **`screenshot()` 函数**：多处使用 `unwrap()` 处理屏幕捕获、文件写入等操作
4. **`cut_image()` 和 `do_finish_ocr()`**：同样存在 `unwrap()` 问题

生产环境可能因为以下原因触发这些错误：
- OCR 二进制文件未正确打包
- 资源路径在打包后发生变化
- 缺少屏幕录制权限
- 文件系统权限问题

## 修复内容 / Changes

- ✅ 将所有 `unwrap()` 替换为 `match` 表达式和适当的错误处理
- ✅ 在 macOS 上添加 OCR 二进制文件存在性检查
- ✅ 改进错误消息，提供更多调试上下文
- ✅ 优雅地处理 `APP_HANDLE.get()` 失败的情况
- ✅ 将 panic 改为通过 `eprintln!` 记录错误日志

## 受影响的函数 / Affected Functions

| 函数 | 平台 | 修复内容 |
|------|------|----------|
| `cut_image()` | All | 安全处理 APP_HANDLE 和路径解析 |
| `screenshot()` | All | 全面的屏幕捕获错误处理 |
| `do_ocr()` | macOS | 检查二进制存在性，改进错误传播 |
| `ocr()` | All | 捕获并记录错误，而不是 unwrap |
| `do_finish_ocr()` | Windows | 安全处理 APP_HANDLE 和路径 |

## 测试建议 / Testing Suggestions

1. 在生产构建中测试 OCR 功能
2. 移除 OCR 二进制文件测试错误处理
3. 在无屏幕录制权限时测试截屏功能